### PR TITLE
Disable OpenVino compiled model caching to prevent doubling of RAM usage on subsequent program starts.

### DIFF
--- a/main.py
+++ b/main.py
@@ -286,6 +286,7 @@ class MainWindow(QMainWindow):
                     scheduler=scheduler,
                     compile=False,
                     local_files_only=self.use_local_model_folder.isChecked(),
+                    ov_config={"CACHE_DIR":""},
                 )
             else:
                 if self.pipeline:


### PR DESCRIPTION
Optimum doesn't even use cached models but still keeps them around in ram.
After fix RAM usage went from 14.1 GB to 7.26 GB