### PR TITLE
Abort tiled upscale if using OpenVINO

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -282,6 +282,9 @@ else:
         # input = Image.open(args.file)
         # upscale_image(input, "results/fastSD-" + str(int(time.time())) + ".png")
         # result.save("results/fastSD-" + str(int(time.time())) + ".png")
+        if args.use_openvino:
+            print("ERROR : At the moment Tiled upscale doesn't work with OpenVINO models")
+            exit()
         upscale_settings = None
         if args.custom_settings:
             with open(args.custom_settings) as f:


### PR DESCRIPTION
It seems the error when using tiled upscale with OpenVINO models is related to the output resolution for the generated images; the current code for tiled upscale uses arbitrary resolutions, which is not really compatible with OpenVINO anyway given that OpenVINO models have to be recompiled whenever output resolution changes; with the current tiled upscale code, OpenVINO models would require recompilation at every tile generation.

So, for the time being, it's best to abort execution of the tiled upscale when the _use_openvino_ argument is set.