### PR TITLE
Minor changes to tiled upscale code

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -303,20 +303,26 @@ else:
         )
     # Perform Tiled SD upscale (EXPERIMENTAL)
     elif args.sdupscale:
-        config.lcm_diffusion_setting.strength = 0.3 if args.use_openvino else 0.1
+        if args.use_openvino:
+            config.lcm_diffusion_setting.strength = 0.3
         upscale_settings = None
-        output_path = FastStableDiffusionPaths.get_upscale_filepath(
-            args.file,
-            2,
-            config.generated_images.format,
-        )
         if args.custom_settings:
             with open(args.custom_settings) as f:
                 upscale_settings = json.load(f)
+        filepath = args.file
+        output_format = config.generated_images.format
+        if upscale_settings:
+            filepath = upscale_settings["source_file"]
+            output_format = upscale_settings["target_format"].upper()
+        output_path = FastStableDiffusionPaths.get_upscale_filepath(
+            filepath,
+            2,
+            output_format,
+        )
 
         generate_upscaled_image(
             config,
-            Image.open(args.file),
+            filepath,
             config.lcm_diffusion_setting.strength,
             upscale_settings=upscale_settings,
             context=context,

--- a/src/backend/upscale/tiled_upscale.py
+++ b/src/backend/upscale/tiled_upscale.py
@@ -9,7 +9,7 @@ from constants import DEVICE
 
 def generate_upscaled_image(
     config,
-    input_image=None,
+    input_path=None,
     strength=0.3,
     scale_factor=2.0,
     tile_overlap=16,
@@ -19,7 +19,7 @@ def generate_upscaled_image(
     image_format="PNG",
 ):
     if config == None or (
-        input_image == None or input_image == "" and upscale_settings == None
+        input_path == None or input_path == "" and upscale_settings == None
     ):
         logging.error("Wrong arguments in tiled upscale function call!")
         return
@@ -28,15 +28,17 @@ def generate_upscaled_image(
     # upscale_settings dict using the function arguments and default values
     if upscale_settings == None:
         upscale_settings = {
-            "source_file": input_image,
+            "source_file": input_path,
             "target_file": None,
+            "target_format": image_format,
             "strength": strength,
             "scale_factor": scale_factor,
+            "prompt": config.lcm_diffusion_setting.prompt,
             "tile_overlap": tile_overlap,
             "tile_size": 256,
             "tiles": [],
         }
-        source_image = input_image  # PIL image
+        source_image = Image.open(input_path)  # PIL image
     else:
         source_image = Image.open(upscale_settings["source_file"])
 
@@ -91,7 +93,7 @@ def generate_upscaled_image(
                         "w": w,
                         "h": h,
                         "mask_box": mask_box,
-                        "prompt": None,
+                        "prompt": upscale_settings["prompt"],  # Use top level prompt if available
                         "scale_factor": scale_factor,
                     }
                 )
@@ -106,7 +108,7 @@ def generate_upscaled_image(
         )
 
     # Save completed upscaled image
-    if image_format == "JPEG":
+    if upscale_settings["target_format"].upper() == "JPEG":
         result_rgb = result.convert("RGB")
         result.close()
         result = result_rgb

--- a/src/paths.py
+++ b/src/paths.py
@@ -73,7 +73,7 @@ class FastStableDiffusionPaths:
         extension = get_image_file_extension(format)
         upscaled_filepath = join_paths(
             FastStableDiffusionPaths.get_results_path(),
-            f"{file_name_src}_{int(scale_factor)}x_upscale_{int(time())}.{extension}",
+            f"{file_name_src}_{int(scale_factor)}x_upscale_{int(time())}{extension}",
         )
         return upscaled_filepath
 


### PR DESCRIPTION
This commit attempts to honor tiled upscale JSON settings for output format, source file, etc.. Both CLI arguments and JSON settings should work; if both are present, JSON settings override CLI arguments.

Also, it's now possible to define a top level prompt for tiled upscale either by using the _--prompt_ CLI argument or a top level prompt in JSON settings that must be present even if set to _null_. I realized that sometimes using promptless image variations for tiled upscale may result in completely disjointed tiles; providing a top level prompt might improve tile consistency, usually the same prompt used to generate the original image would work.