### PR TITLE
Basic LoRA support

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -192,6 +192,12 @@ parser.add_argument(
     action="store_true",
     help="Disable image saving",
 )
+parser.add_argument(
+    "--lora",
+    type=str,
+    help="LoRA model",
+    default=None,
+)
 args = parser.parse_args()
 
 if args.version:
@@ -265,6 +271,7 @@ else:
     config.lcm_diffusion_setting.lcm_lora.base_model_id = args.base_model_id
     config.lcm_diffusion_setting.lcm_lora.lcm_lora_id = args.lcm_lora_id
     config.lcm_diffusion_setting.diffusion_task = DiffusionTask.text_to_image.value
+    config.lcm_diffusion_setting.lora_path = args.lora
     if args.usejpeg:
         config.generated_images.format = ImageFormat.JPEG.value.upper()
 

--- a/src/app.py
+++ b/src/app.py
@@ -199,6 +199,12 @@ parser.add_argument(
     help="LoRA model",
     default=None,
 )
+parser.add_argument(
+    "--lora_weight",
+    type=float,
+    help="LoRA weight",
+    default=0.5,
+)
 args = parser.parse_args()
 
 if args.version:
@@ -273,6 +279,8 @@ else:
     config.lcm_diffusion_setting.lcm_lora.lcm_lora_id = args.lcm_lora_id
     config.lcm_diffusion_setting.diffusion_task = DiffusionTask.text_to_image.value
     config.lcm_diffusion_setting.lora_path = args.lora
+    config.lcm_diffusion_setting.lora_weight = args.lora_weight
+    config.lcm_diffusion_setting.fuse_lora = True
     if args.usejpeg:
         config.generated_images.format = ImageFormat.JPEG.value.upper()
     if args.seed > -1:

--- a/src/backend/lcm_text_to_image.py
+++ b/src/backend/lcm_text_to_image.py
@@ -154,6 +154,7 @@ class LCMTextToImage:
                         lcm_lora.lcm_lora_id,
                         use_local_model,
                         torch_data_type=self.torch_data_type,
+                        lcm_diffusion_setting=lcm_diffusion_setting,
                     )
                 else:
                     print(f"***** Init LCM Model pipeline - {model_id} *****")
@@ -164,17 +165,19 @@ class LCMTextToImage:
                     if lcm_diffusion_setting.lora_path:
                         lora_dir = os.path.dirname(lcm_diffusion_setting.lora_path)
                         lora_name = os.path.basename(lcm_diffusion_setting.lora_path)
+                        adapter_name = os.path.splitext(lora_name)[0]
                         self.pipeline.load_lora_weights(
                             lora_dir,
                             weight_name=lora_name,
                             local_files_only=True,
-                            adapter_name="lora",
+                            adapter_name=adapter_name,
                         )
                         self.pipeline.set_adapters(
-                            ["lora"],
-                            adapter_weights=[0.5],
+                            [adapter_name],
+                            adapter_weights=[lcm_diffusion_setting.lora_weight],
                         )
-                        # self.pipeline.fuse_lora()
+                        if lcm_diffusion_setting.fuse_lora:
+                            self.pipeline.fuse_lora()
 
                 if (
                     lcm_diffusion_setting.diffusion_task

--- a/src/backend/lcm_text_to_image.py
+++ b/src/backend/lcm_text_to_image.py
@@ -1,6 +1,7 @@
 from typing import Any
 from diffusers import LCMScheduler
 import torch
+import os.path
 from backend.models.lcmdiffusion_setting import LCMDiffusionSetting
 import numpy as np
 from constants import DEVICE
@@ -160,6 +161,20 @@ class LCMTextToImage:
                         model_id,
                         use_local_model,
                     )
+                    if lcm_diffusion_setting.lora_path:
+                        lora_dir = os.path.dirname(lcm_diffusion_setting.lora_path)
+                        lora_name = os.path.basename(lcm_diffusion_setting.lora_path)
+                        self.pipeline.load_lora_weights(
+                            lora_dir,
+                            weight_name=lora_name,
+                            local_files_only=True,
+                            adapter_name="lora",
+                        )
+                        self.pipeline.set_adapters(
+                            ["lora"],
+                            adapter_weights=[0.5],
+                        )
+                        # self.pipeline.fuse_lora()
 
                 if (
                     lcm_diffusion_setting.diffusion_task

--- a/src/backend/models/lcmdiffusion_setting.py
+++ b/src/backend/models/lcmdiffusion_setting.py
@@ -37,3 +37,4 @@ class LCMDiffusionSetting(BaseModel):
     use_seed: bool = False
     use_safety_checker: bool = False
     diffusion_task: str = DiffusionTask.text_to_image.value
+    lora_path: Any = None

--- a/src/backend/models/lcmdiffusion_setting.py
+++ b/src/backend/models/lcmdiffusion_setting.py
@@ -37,4 +37,6 @@ class LCMDiffusionSetting(BaseModel):
     use_seed: bool = False
     use_safety_checker: bool = False
     diffusion_task: str = DiffusionTask.text_to_image.value
-    lora_path: Any = None
+    lora_path: Optional[Any] = None
+    lora_weight: Optional[float] = 0.5
+    fuse_lora: bool = True


### PR DESCRIPTION
Basic LoRA support for LCM and LCM-LoRA models, not yet available for OpenVINO.

Please note this time I had to dig deeper into the code in order to load the LoRA weights, however, if no LoRA path is provided and with _fuse_lora_ kept at its default value of _True_, the code should behave exactly as it did before. Note that this code is just meant to test LoRA support and it's subject to change.

I turned _fuse_lora_ into a setting because, even if the documentation states that it's meant to produce slightly faster inference times, on my machine it's actually somewhat slower; if kept at the default value of _True_, the code should behave exactly as before.

This code works with LCM and LCM-LoRA models, not sure if the same approach would work with OpenVINO. Also, a similar code _should_ work with SDXL models but I can't test it since I can't run SDXL based inference.