### PR TITLE
Add multiple LoRA support

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -258,9 +258,6 @@ else:
     context = get_context(InterfaceType.CLI)
     config = app_settings.settings
 
-    if config.lcm_diffusion_setting.lora.path:
-        config.lcm_diffusion_setting.lora.enabled = True
-
     if args.use_openvino:
         config.lcm_diffusion_setting.lcm_model_id = LCM_DEFAULT_MODEL_OPENVINO
     else:
@@ -280,9 +277,12 @@ else:
     config.lcm_diffusion_setting.lcm_lora.base_model_id = args.base_model_id
     config.lcm_diffusion_setting.lcm_lora.lcm_lora_id = args.lcm_lora_id
     config.lcm_diffusion_setting.diffusion_task = DiffusionTask.text_to_image.value
+    config.lcm_diffusion_setting.lora.enabled = False
     config.lcm_diffusion_setting.lora.path = args.lora
     config.lcm_diffusion_setting.lora.weight = args.lora_weight
     config.lcm_diffusion_setting.lora.fuse = True
+    if config.lcm_diffusion_setting.lora.path:
+        config.lcm_diffusion_setting.lora.enabled = True
     if args.usejpeg:
         config.generated_images.format = ImageFormat.JPEG.value.upper()
     if args.seed > -1:
@@ -295,6 +295,7 @@ else:
     # Interactive mode
     if args.interactive:
         # wrapper(interactive_mode, config, context)
+        config.lcm_diffusion_setting.lora.fuse = False
         interactive_mode(config, context)
 
     # Start of non-interactive CLI image generation

--- a/src/backend/lcm_text_to_image.py
+++ b/src/backend/lcm_text_to_image.py
@@ -116,8 +116,13 @@ class LCMTextToImage:
             or self.previous_ov_model_id != ov_model_id
             or self.previous_safety_checker != lcm_diffusion_setting.use_safety_checker
             or self.previous_use_openvino != lcm_diffusion_setting.use_openvino
-            or self.previous_task_type != lcm_diffusion_setting.diffusion_task
-            or self.previous_lora != lcm_diffusion_setting.lora
+            or (
+                self.use_openvino
+                and (
+                    self.previous_task_type != lcm_diffusion_setting.diffusion_task
+                    or self.previous_lora != lcm_diffusion_setting.lora
+                )
+            )
         ):
             if self.use_openvino and is_openvino_device():
                 if self.pipeline:
@@ -168,13 +173,12 @@ class LCMTextToImage:
                         use_local_model,
                     )
 
-                if (
-                    lcm_diffusion_setting.diffusion_task
-                    == DiffusionTask.image_to_image.value
-                ):
-                    self.img_to_img_pipeline = get_image_to_image_pipeline(
-                        self.pipeline
-                    )
+                # if (
+                #     lcm_diffusion_setting.diffusion_task
+                #     == DiffusionTask.image_to_image.value
+                # ):
+                # Always create both, txt2img and img2img pipelines
+                self.img_to_img_pipeline = get_image_to_image_pipeline(self.pipeline)
 
                 # Load LoRA weight for pytorch pipeline (.safetensors)
                 if lcm_diffusion_setting.lora.enabled:
@@ -194,24 +198,24 @@ class LCMTextToImage:
                     )
                 else:
                     print("Using Tiny Auto Encoder")
-                    if (
-                        lcm_diffusion_setting.diffusion_task
-                        == DiffusionTask.text_to_image.value
-                    ):
-                        load_taesd(
-                            self.pipeline,
-                            use_local_model,
-                            self.torch_data_type,
-                        )
-                    elif (
-                        lcm_diffusion_setting.diffusion_task
-                        == DiffusionTask.image_to_image.value
-                    ):
-                        load_taesd(
-                            self.img_to_img_pipeline,
-                            use_local_model,
-                            self.torch_data_type,
-                        )
+                    # if (
+                    #     lcm_diffusion_setting.diffusion_task
+                    #     == DiffusionTask.text_to_image.value
+                    # ):
+                    load_taesd(
+                        self.pipeline,
+                        use_local_model,
+                        self.torch_data_type,
+                    )
+                    # elif (
+                    #     lcm_diffusion_setting.diffusion_task
+                    #     == DiffusionTask.image_to_image.value
+                    # ):
+                    load_taesd(
+                        self.img_to_img_pipeline,
+                        use_local_model,
+                        self.torch_data_type,
+                    )
 
             if (
                 lcm_diffusion_setting.diffusion_task

--- a/src/backend/lora.py
+++ b/src/backend/lora.py
@@ -1,9 +1,37 @@
 import glob
 from os import path
-
 from paths import get_file_name
 
 
+# A basic class to keep track of the currently loaded LoRAs and
+# their weights; the diffusers funtion \c get_active_adapters()
+# returns a list of adapter names but not their weights so we need
+# a way to keep track of the current LoRA weights to set whenever
+# a new LoRA is loaded
+class _lora_info:
+    def __init__(
+        self,
+        path: str,
+        weight: float,
+    ):
+        self.path = path
+        self.adapter_name = get_file_name(path)
+        self.weight = weight
+
+    def __del__(self):
+        self.path = None
+        self.adapter_name = None
+
+
+_loaded_loras = []
+_current_pipeline = None
+
+
+# This function loads a LoRA from the LoRA path setting, so it's
+# possible to load multiple LoRAs by calling this function more than
+# once with a different LoRA path setting; note that if you plan to
+# load multiple LoRAs and dynamically change their weights, you
+# might want to set the LoRA fuse option to False
 def load_lora_weight(
     pipeline,
     lcm_diffusion_setting,
@@ -14,34 +42,34 @@ def load_lora_weight(
     if not path.exists(lcm_diffusion_setting.lora.path):
         raise Exception("Lora model path is invalid")
 
+    # If the pipeline has been rebuilt since the last call, remove all
+    # references to previously loaded LoRAs and store the new pipeline
+    global _loaded_loras
+    global _current_pipeline
+    if pipeline != _current_pipeline:
+        for lora in _loaded_loras:
+            del lora
+        del _loaded_loras
+        _loaded_loras = []
+        _current_pipeline = pipeline
+
+    current_lora = _lora_info(
+        lcm_diffusion_setting.lora.path,
+        lcm_diffusion_setting.lora.weight,
+    )
+    _loaded_loras.append(current_lora)
+
     if lcm_diffusion_setting.lora.enabled:
-        adapter_name = get_file_name(lcm_diffusion_setting.lora.path)
-        print(f"LoRA adapter name : {adapter_name}")
+        print(f"LoRA adapter name : {current_lora.adapter_name}")
         pipeline.load_lora_weights(
-            lcm_diffusion_setting.lora.path,
+            current_lora.path,
             local_files_only=True,
-            adapter_name=adapter_name,
+            adapter_name=current_lora.adapter_name,
         )
-        if lcm_diffusion_setting.use_lcm_lora:
-            pipeline.set_adapters(
-                [
-                    "lcm",
-                    adapter_name,
-                ],
-                adapter_weights=[
-                    1.0,
-                    lcm_diffusion_setting.lora.weight,
-                ],
-            )
-        else:
-            pipeline.set_adapters(
-                [
-                    adapter_name,
-                ],
-                adapter_weights=[
-                    lcm_diffusion_setting.lora.weight,
-                ],
-            )
+        update_lora_weights(
+            pipeline,
+            lcm_diffusion_setting,
+        )
 
         if lcm_diffusion_setting.lora.fuse:
             pipeline.fuse_lora()
@@ -55,3 +83,50 @@ def get_lora_models(root_dir: str):
         if lora_name is not None:
             lora_models_map[lora_name] = file_path
     return lora_models_map
+
+
+# This function returns a list of (adapter_name, weight) tuples for the
+# currently loaded LoRAs
+def get_active_lora_weights():
+    active_loras = []
+    for lora_info in _loaded_loras:
+        active_loras.append(
+            (
+                lora_info.adapter_name,
+                lora_info.weight,
+            )
+        )
+    return active_loras
+
+
+# This function receives a pipeline, an lcm_diffusion_setting object and
+# an optional list of updated (adapter_name, weight) tuples
+def update_lora_weights(
+    pipeline,
+    lcm_diffusion_setting,
+    lora_weights=None,
+):
+    global _loaded_loras
+    global _current_pipeline
+    if pipeline != _current_pipeline:
+        print("Wrong pipeline when trying to update LoRA weights")
+        return
+    if lora_weights:
+        for idx, lora in enumerate(lora_weights):
+            if _loaded_loras[idx].adapter_name != lora[0]:
+                print("Wrong adapter name in LoRA enumeration!")
+                continue
+            _loaded_loras[idx].weight = lora[1]
+
+    adapter_names = []
+    adapter_weights = []
+    if lcm_diffusion_setting.use_lcm_lora:
+        adapter_names.append("lcm")
+        adapter_weights.append(1.0)
+    for lora in _loaded_loras:
+        adapter_names.append(lora.adapter_name)
+        adapter_weights.append(lora.weight)
+    pipeline.set_adapters(
+        adapter_names,
+        adapter_weights=adapter_weights,
+    )

--- a/src/frontend/cli_interactive.py
+++ b/src/frontend/cli_interactive.py
@@ -279,6 +279,7 @@ def interactive_img2img(
     user_input = input("Write a prompt (write 'exit' to quit): ")
     while True:
         if user_input == "exit":
+            settings.inference_steps = steps
             return
         settings.init_image = Image.open(source_path)
         settings.prompt = user_input
@@ -327,6 +328,7 @@ def interactive_variations(
             )
         user_input = input("Continue in Image variations mode? (Y/n): ")
         if user_input.upper() == "N":
+            settings.inference_steps = steps
             return
         new_path = input(f"Image path ({source_path}): ")
         if new_path != "":
@@ -531,4 +533,5 @@ def interactive_sdupscale(
         )
         user_input = input("Continue in SD Upscale mode? (Y/n): ")
         if user_input.upper() == "N":
+            settings.inference_steps = steps
             return

--- a/src/frontend/cli_interactive.py
+++ b/src/frontend/cli_interactive.py
@@ -142,19 +142,20 @@ def interactive_lora(config, context, menu_flag=False):
             )
     elif option == 2:
         # Load a new LoRA
-        dummy_settings = LCMDiffusionSetting()
-        dummy_settings.lora.fuse = False
-        dummy_settings.lora.enabled = True
-        dummy_settings.lora.path = input("Enter LoRA model path: ")
-        dummy_settings.lora.weight = user_value(
+        settings = config.lcm_diffusion_setting
+        settings.lora.fuse = False
+        settings.lora.enabled = False
+        settings.lora.path = input("Enter LoRA model path: ")
+        settings.lora.weight = user_value(
             float,
             "Enter a LoRA weight (0.5): ",
             0.5,
         )
-        if not path.exists(dummy_settings.lora.path):
+        if not path.exists(settings.lora.path):
             print("Invalid LoRA model path!")
             return
-        load_lora_weight(context.lcm_text_to_image.pipeline, dummy_settings)
+        settings.lora.enabled = True
+        load_lora_weight(context.lcm_text_to_image.pipeline, settings)
 
     if menu_flag:
         global _edit_lora_settings

--- a/src/frontend/cli_interactive.py
+++ b/src/frontend/cli_interactive.py
@@ -19,6 +19,7 @@ from backend.models.lcmdiffusion_setting import (
 
 
 _batch_count = 1
+_edit_lora_settings = False
 
 
 def user_value(
@@ -92,15 +93,17 @@ def interactive_mode(
             interactive_lora(
                 config,
                 context,
+                True,
             )
         elif option == 8:
             exit()
 
 
-def interactive_lora(
-    config,
-    context,
-):
+def interactive_lora(config, context, menu_flag=False):
+    """
+    @param menu_flag: Indicates whether this function was called from the main
+        interactive CLI menu; _True_ if called from the main menu, _False_ otherwise
+    """
     if context == None or context.lcm_text_to_image.pipeline == None:
         print("Diffusion pipeline not initialized, please run a generation task first!")
         return
@@ -152,6 +155,13 @@ def interactive_lora(
             print("Invalid LoRA model path!")
             return
         load_lora_weight(context.lcm_text_to_image.pipeline, dummy_settings)
+
+    if menu_flag:
+        global _edit_lora_settings
+        _edit_lora_settings = False
+        option = input("Edit LoRA settings after every generation? (y/N): ")
+        if option.upper() == "Y":
+            _edit_lora_settings = True
 
 
 def interactive_settings(
@@ -255,6 +265,11 @@ def interactive_txt2img(
                 settings=config,
                 device=DEVICE,
             )
+        if _edit_lora_settings:
+            interactive_lora(
+                config,
+                context,
+            )
         user_input = input("Write a prompt: ")
 
 
@@ -296,6 +311,11 @@ def interactive_img2img(
             f"img2img strength ({settings.strength}): ",
             settings.strength,
         )
+        if _edit_lora_settings:
+            interactive_lora(
+                config,
+                context,
+            )
         settings.inference_steps = int(steps / settings.strength + 1)
         user_input = input("Write a prompt: ")
 
@@ -325,6 +345,11 @@ def interactive_variations(
             generate_image_variations(
                 settings.init_image,
                 settings.strength,
+            )
+        if _edit_lora_settings:
+            interactive_lora(
+                config,
+                context,
             )
         user_input = input("Continue in Image variations mode? (Y/n): ")
         if user_input.upper() == "N":

--- a/src/frontend/webui/lora_models_ui.py
+++ b/src/frontend/webui/lora_models_ui.py
@@ -48,21 +48,22 @@ def on_click_load_lora(lora_name, lora_weight):
     )
 
     # Load a new LoRA
-    dummy_settings = LCMDiffusionSetting()
-    dummy_settings.lora.fuse = False
-    dummy_settings.lora.enabled = True
-    dummy_settings.lora.path = lora_models_map[lora_name]
-    dummy_settings.lora.weight = lora_weight
-    if not path.exists(dummy_settings.lora.path):
+    settings = app_settings.settings.lcm_diffusion_setting
+    settings.lora.fuse = False
+    settings.lora.enabled = False
+    settings.lora.path = lora_models_map[lora_name]
+    settings.lora.weight = lora_weight
+    if not path.exists(settings.lora.path):
         gr.Warning("Invalid LoRA model path!")
         return
     pipeline = get_context(InterfaceType.WEBUI).lcm_text_to_image.pipeline
     if not pipeline:
         gr.Warning("Pipeline not initialized. Please generate an image first.")
         return
+    settings.lora.enabled = True
     load_lora_weight(
         get_context(InterfaceType.WEBUI).lcm_text_to_image.pipeline,
-        dummy_settings,
+        settings,
     )
 
     # Update Gradio LoRA UI

--- a/src/frontend/webui/ui.py
+++ b/src/frontend/webui/ui.py
@@ -76,4 +76,5 @@ def start_webui(
     share: bool = False,
 ):
     webui = get_web_ui()
+    webui.queue()
     webui.launch(share=share)

--- a/src/frontend/webui/ui.py
+++ b/src/frontend/webui/ui.py
@@ -32,6 +32,11 @@ def get_web_ui() -> gr.Blocks:
         elif mode == "LCM-OpenVINO":
             app_settings.settings.lcm_diffusion_setting.use_openvino = True
 
+        # Disable app settings LoRA model from being loaded by default when
+        # the diffusion pipeline is created; LoRAs must be loaded from the WebUI
+        if app_settings.settings.lcm_diffusion_setting.lora:
+            app_settings.settings.lcm_diffusion_setting.lora.enabled = False
+
     with gr.Blocks(
         css=FastStableDiffusionPaths.get_css_path(),
         title="FastSD CPU",


### PR DESCRIPTION
This commit adds multiple LoRA support and updates interactive CLI mode to allow loading/editing LoRA weights dynamically.

As an example, the following images were generated by dynamically loading/editing LoRA weights, using the same seed and same prompt by first launching CLI interactive mode using the _--lora_ argument (the prompt includes the trigger words for both used LoRAs); the following is the image generated using the _Jane_ LoRA from the CLI argument:
![740a7f4b-3657-4eed-af8a-07f8bc0665ae-1](https://github.com/rupeshs/fastsdcpu/assets/29698839/f4fb2121-5aba-411c-b48d-9b5c1f0ce686)

Next, an _ancient-chinese-scroll_ LoRA is loaded and the following image is generated:
![cc44f35d-ac49-42d7-b692-c281f86c24ff-1](https://github.com/rupeshs/fastsdcpu/assets/29698839/589933bc-bb4d-4049-a76e-71144fdc19dc)

Next, LoRA weights are set to 0.0 for both LoRAs, effectively returning to using just the base model:
![3cbf5781-c1a5-4998-9c19-7ba3149c3fdd-1](https://github.com/rupeshs/fastsdcpu/assets/29698839/20af36ae-af8f-4f23-879b-75f6b72a0c37)

Please note that the current LoRA code in the FastSD CPU repository is hardcoded to support only one LoRA (the whole pipeline is rebuilt if the LoRA changes) and I didn't want to risk breaking anything so I had to work around that limitation; however, it should be trivial to write the required changes.

In the next post I'll write some extra considerations to take into account when using multiple LoRAs.
