### PR TITLE
Add ability to specify API server port

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -229,6 +229,12 @@ parser.add_argument(
     help="LoRA adapter weight [0 to 1.0]",
     default=0.5,
 )
+parser.add_argument(
+    "--port",
+    type=int,
+    help="Web server port",
+    default=8000,
+)
 
 args = parser.parse_args()
 
@@ -289,7 +295,7 @@ elif args.realtime:
 elif args.api:
     from backend.api.web import start_web_server
 
-    start_web_server()
+    start_web_server(args.port)
 
 else:
     context = get_context(InterfaceType.CLI)

--- a/src/backend/api/web.py
+++ b/src/backend/api/web.py
@@ -95,9 +95,9 @@ async def generate(diffusion_config: LCMDiffusionSetting) -> StableDiffusionResp
     )
 
 
-def start_web_server():
+def start_web_server(port: int = 8000):
     uvicorn.run(
         app,
         host="0.0.0.0",
-        port=8000,
+        port=port,
     )


### PR DESCRIPTION
## The WHY

As 8000 is a fairly common default port in web applications, it's beneficial to have the ability to choose a port for the API web server.

## The WHAT

An optional `--port` argument has been added to argparser. The default value is 8000 as before, but now it's possible to override it with a value of choosing. 
