### PR TITLE
Fix safety checker for some models

### DIFF
--- a/src/backend/lcm_text_to_image.py
+++ b/src/backend/lcm_text_to_image.py
@@ -177,12 +177,10 @@ class LCMTextToImage:
                         use_local_model,
                     )
             else:
-                if self.pipeline:
-                    del self.pipeline
+                if self.pipeline or self.img_to_img_pipeline:
                     self.pipeline = None
-                if self.img_to_img_pipeline:
-                    del self.img_to_img_pipeline
                     self.img_to_img_pipeline = None
+                    gc.collect()
 
                 controlnet_args = load_controlnet_adapters(lcm_diffusion_setting)
                 if use_lora:

--- a/src/backend/lcm_text_to_image.py
+++ b/src/backend/lcm_text_to_image.py
@@ -114,6 +114,7 @@ class LCMTextToImage:
         self.use_openvino = lcm_diffusion_setting.use_openvino
         model_id = lcm_diffusion_setting.lcm_model_id
         use_local_model = lcm_diffusion_setting.use_offline_model
+        use_safety_checker = lcm_diffusion_setting.use_safety_checker
         use_tiny_auto_encoder = lcm_diffusion_setting.use_tiny_auto_encoder
         use_lora = lcm_diffusion_setting.use_lcm_lora
         lcm_lora: LCMLora = lcm_diffusion_setting.lcm_lora
@@ -192,6 +193,7 @@ class LCMTextToImage:
                         lcm_lora.base_model_id,
                         lcm_lora.lcm_lora_id,
                         use_local_model,
+                        use_safety_checker,
                         torch_data_type=self.torch_data_type,
                         pipeline_args=controlnet_args,
                     )
@@ -201,6 +203,7 @@ class LCMTextToImage:
                     self.pipeline = get_lcm_model_pipeline(
                         model_id,
                         use_local_model,
+                        use_safety_checker,
                         controlnet_args,
                     )
 

--- a/src/backend/pipelines/lcm.py
+++ b/src/backend/pipelines/lcm.py
@@ -59,9 +59,13 @@ def load_taesd(
 def get_lcm_model_pipeline(
     model_id: str = LCM_DEFAULT_MODEL,
     use_local_model: bool = False,
+    use_safety_checker: bool = False,
     pipeline_args={},
 ):
     pipeline = None
+    safety_checker_args = {}
+    if not use_safety_checker:
+        safety_checker_args['safety_checker'] = None
     if model_id == "latent-consistency/lcm-sdxl":
         pipeline = _get_lcm_pipeline_from_base_model(
             model_id,
@@ -81,9 +85,9 @@ def get_lcm_model_pipeline(
         # defines the method from_single_file()
         dummy_pipeline = StableDiffusionPipeline.from_single_file(
             model_id,
-            safety_checker=None,
             local_files_only=use_local_model,
             use_safetensors=True,
+            **safety_checker_args,
         )
         if 'lcm' in model_id.lower():
             dummy_pipeline.scheduler = LCMScheduler.from_config(dummy_pipeline.scheduler.config)
@@ -98,6 +102,7 @@ def get_lcm_model_pipeline(
         pipeline = AutoPipelineForText2Image.from_pretrained(
             model_id,
             local_files_only=use_local_model,
+            **safety_checker_args,
             **pipeline_args,
         )
 

--- a/src/backend/pipelines/lcm.py
+++ b/src/backend/pipelines/lcm.py
@@ -82,8 +82,6 @@ def get_lcm_model_pipeline(
         dummy_pipeline = StableDiffusionPipeline.from_single_file(
             model_id,
             safety_checker=None,
-            run_safety_checker=False,
-            load_safety_checker=False,
             local_files_only=use_local_model,
             use_safetensors=True,
         )

--- a/src/backend/pipelines/lcm_lora.py
+++ b/src/backend/pipelines/lcm_lora.py
@@ -29,9 +29,13 @@ def get_lcm_lora_pipeline(
     base_model_id: str,
     lcm_lora_id: str,
     use_local_model: bool,
+    use_safety_checker: bool,
     torch_data_type: torch.dtype,
     pipeline_args={},
 ):
+    safety_checker_args = {}
+    if not use_safety_checker:
+        safety_checker_args['safety_checker'] = None
     if pathlib.Path(base_model_id).suffix == ".safetensors":
         # SD 1.5 models only
         # When loading a .safetensors model, the pipeline has to be created
@@ -48,9 +52,9 @@ def get_lcm_lora_pipeline(
         dummy_pipeline = StableDiffusionPipeline.from_single_file(
             base_model_id,
             torch_dtype=torch_data_type,
-            safety_checker=None,
             local_files_only=use_local_model,
             use_safetensors=True,
+            **safety_checker_args,
         )
         pipeline = AutoPipelineForText2Image.from_pipe(
             dummy_pipeline,
@@ -62,6 +66,7 @@ def get_lcm_lora_pipeline(
             base_model_id,
             torch_dtype=torch_data_type,
             local_files_only=use_local_model,
+            **safety_checker_args,
             **pipeline_args,
         )
 

--- a/src/backend/pipelines/lcm_lora.py
+++ b/src/backend/pipelines/lcm_lora.py
@@ -49,7 +49,6 @@ def get_lcm_lora_pipeline(
             base_model_id,
             torch_dtype=torch_data_type,
             safety_checker=None,
-            load_safety_checker=False,
             local_files_only=use_local_model,
             use_safetensors=True,
         )


### PR DESCRIPTION
The first changeset fixes safety checker behavior for models which do not incorporate the safety model internally (safetensors and some diffusers models).

The other two are somewhat-related minor memory optimizations.

Unfortunately, I couldn't make the check work on OpenVINO at all, regardless of this change (but I can't test it very well, it's too memory-hungry for my PC). If the filter is enabled on OpenVINO, _and_ not working, this change may cause a crash instead; but it shouldn't interfere on a correctly working checker.