### PR TITLE
Seeding improvements

### DIFF
--- a/src/backend/image_saver.py
+++ b/src/backend/image_saver.py
@@ -34,7 +34,14 @@ class ImageSaver:
         gen_id = uuid4()
 
         if images:
+            image_seeds = []
+
             for index, image in enumerate(images):
+
+                image_seed = image.info.get('image_seed')
+                if image_seed is not None:
+                    image_seeds.append(image_seed)
+
                 if not path.exists(output_path):
                     mkdir(output_path)
 
@@ -51,11 +58,12 @@ class ImageSaver:
                 image_extension = get_image_file_extension(format)
                 image.save(path.join(out_path, f"{gen_id}-{index+1}{image_extension}"))
             if lcm_diffusion_setting:
+                data = lcm_diffusion_setting.model_dump(exclude=get_exclude_keys())
+                if image_seeds:
+                    data['image_seeds'] = image_seeds
                 with open(path.join(out_path, f"{gen_id}.json"), "w") as json_file:
                     json.dump(
-                        lcm_diffusion_setting.model_dump(
-                            exclude=get_exclude_keys(),
-                        ),
+                        data,
                         json_file,
                         indent=4,
                     )

--- a/src/backend/lcm_text_to_image.py
+++ b/src/backend/lcm_text_to_image.py
@@ -1,6 +1,7 @@
 import gc
 from math import ceil
 from typing import Any, List
+import random
 
 import numpy as np
 import torch
@@ -395,15 +396,22 @@ class LCMTextToImage:
                 f"Strength: {lcm_diffusion_setting.strength},{img_to_img_inference_steps}"
             )
 
+        pipeline_extra_args = {}
+
         if lcm_diffusion_setting.use_seed:
             cur_seed = lcm_diffusion_setting.seed
-            if self.use_openvino:
-                if self._is_hetero_pipeline():
-                    torch.manual_seed(cur_seed)
-                else:
-                    np.random.seed(cur_seed)
-            else:
-                torch.manual_seed(cur_seed)
+            # for multiple images with a fixed seed, use sequential seeds
+            seeds = [(cur_seed + i) for i in range(lcm_diffusion_setting.number_of_images)]
+        else:
+            seeds = [random.randint(0,999999999) for i in range(lcm_diffusion_setting.number_of_images)]
+
+        if self.use_openvino and not self._is_hetero_pipeline():
+            # no support for generators; try at least to ensure reproducible results for single images
+            np.random.seed(seeds[0])
+
+        else:
+            pipeline_extra_args['generator'] = [
+                torch.Generator(device=self.device).manual_seed(s) for s in seeds]
 
         is_openvino_pipe = lcm_diffusion_setting.use_openvino and is_openvino_device()
         if is_openvino_pipe and not self._is_hetero_pipeline():
@@ -426,7 +434,6 @@ class LCMTextToImage:
         elif lcm_diffusion_setting.use_gguf_model:
             return self._generate_images_gguf(lcm_diffusion_setting)
 
-        pipeline_extra_args = {}
         if lcm_diffusion_setting.clip_skip > 1:
             # We follow the convention that "CLIP Skip == 2" means "skip
             # the last layer", so "CLIP Skip == 1" means "no skipping"
@@ -513,6 +520,10 @@ class LCMTextToImage:
                     **pipeline_extra_args,
                     **controlnet_args,
                 ).images
+
+        for (i, seed) in enumerate(seeds):
+            result_images[i].info['image_seed'] = seed
+
         return result_images
 
     def _init_gguf_diffusion(

--- a/src/backend/lcm_text_to_image.py
+++ b/src/backend/lcm_text_to_image.py
@@ -262,12 +262,10 @@ class LCMTextToImage:
                 #     self.pipeline = None
                 self._init_gguf_diffusion(lcm_diffusion_setting)
             else:
-                if self.pipeline:
-                    del self.pipeline
+                if self.pipeline or self.img_to_img_pipeline:
                     self.pipeline = None
-                if self.img_to_img_pipeline:
-                    del self.img_to_img_pipeline
                     self.img_to_img_pipeline = None
+                    gc.collect()
 
                 controlnet_args = load_controlnet_adapters(lcm_diffusion_setting)
                 if use_lora:


### PR DESCRIPTION
Fixes #80 : use separate PyTorch generators for each image, generate random seeds explicitly, and store them into the JSON data. Also avoid using the same input seed for multiple images.

I also included a minor memory optimization (calling the gc after switching pipelines).