### PR TITLE
Added Upscaler tab to the Qt GUI

### DIFF
--- a/src/backend/upscale/upscaler.py
+++ b/src/backend/upscale/upscaler.py
@@ -17,9 +17,9 @@ def upscale_image(
     dst_image_path: str,
     scale_factor: int = 2,
     upscale_mode: UpscaleMode = UpscaleMode.normal.value,
+    strength: float = 0.1,
 ):
     if upscale_mode == UpscaleMode.normal.value:
-
         upscaled_img = upscale_edsr_2x(src_image_path)
         upscaled_img.save(dst_image_path)
         print(f"Upscaled image saved {dst_image_path}")
@@ -29,7 +29,7 @@ def upscale_image(
         print(f"Upscaled image saved {dst_image_path}")
     else:
         config.settings.lcm_diffusion_setting.strength = (
-            0.3 if config.settings.lcm_diffusion_setting.use_openvino else 0.1
+            0.3 if config.settings.lcm_diffusion_setting.use_openvino else strength
         )
         config.settings.lcm_diffusion_setting.diffusion_task = (
             DiffusionTask.image_to_image.value

--- a/src/frontend/gui/app_window.py
+++ b/src/frontend/gui/app_window.py
@@ -51,6 +51,12 @@ QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
 
 
 class MainWindow(QMainWindow):
+    settings_changed = QtCore.pyqtSignal()
+    """ This signal is used for enabling/disabling the negative prompt field for 
+    modes that support it; in particular, negative prompt is supported with OpenVINO models 
+    and in LCM-LoRA mode but not in LCM mode
+    """
+
     def __init__(self, config: AppSettings):
         super().__init__()
         self.config = config
@@ -146,10 +152,6 @@ class MainWindow(QMainWindow):
                 LCM_DEFAULT_MODEL_OPENVINO,
             )
         )
-        #self.neg_prompt.setEnabled(
-        #    self.config.settings.lcm_diffusion_setting.use_lcm_lora
-        #    or self.config.settings.lcm_diffusion_setting.use_openvino
-        #)
         self.openvino_lcm_model_id.setEnabled(
             self.config.settings.lcm_diffusion_setting.use_openvino
         )
@@ -446,7 +448,6 @@ class MainWindow(QMainWindow):
             self.use_lcm_lora.setEnabled(False)
             self.lcm_lora_id.setEnabled(False)
             self.base_model_id.setEnabled(False)
-            #self.neg_prompt.setEnabled(True)
             self.openvino_lcm_model_id.setEnabled(True)
             self.config.settings.lcm_diffusion_setting.use_openvino = True
         else:
@@ -454,9 +455,9 @@ class MainWindow(QMainWindow):
             self.use_lcm_lora.setEnabled(True)
             self.lcm_lora_id.setEnabled(True)
             self.base_model_id.setEnabled(True)
-            #self.neg_prompt.setEnabled(False)
             self.openvino_lcm_model_id.setEnabled(False)
             self.config.settings.lcm_diffusion_setting.use_openvino = False
+        self.settings_changed.emit()
 
     def use_tae_sd_changed(self, state):
         if state == 2:
@@ -475,14 +476,13 @@ class MainWindow(QMainWindow):
             self.lcm_model.setEnabled(False)
             self.lcm_lora_id.setEnabled(True)
             self.base_model_id.setEnabled(True)
-            #self.neg_prompt.setEnabled(True)
             self.config.settings.lcm_diffusion_setting.use_lcm_lora = True
         else:
             self.lcm_model.setEnabled(True)
             self.lcm_lora_id.setEnabled(False)
             self.base_model_id.setEnabled(False)
-            #self.neg_prompt.setEnabled(False)
             self.config.settings.lcm_diffusion_setting.use_lcm_lora = False
+        self.settings_changed.emit()
 
     def update_clip_skip_label(self, value):
         self.clip_skip_value.setText(f"CLIP Skip: {value}")
@@ -525,7 +525,7 @@ class MainWindow(QMainWindow):
         seed_value = int(self.seed_value.text()) if use_seed else -1
         return seed_value
 
-    #def text_to_image(self):
+    # def text_to_image(self):
     #    self.img.setText("Please wait...")
     #    worker = ImageGeneratorWorker(self.generate_image)
     #    self.threadpool.start(worker)
@@ -554,10 +554,6 @@ class MainWindow(QMainWindow):
     def prepare_generation_settings(self, config):
         """Populate config settings with the values set by the user in the GUI"""
         config.settings.lcm_diffusion_setting.seed = self.get_seed_value()
-        #config.settings.lcm_diffusion_setting.prompt = self.prompt.toPlainText()
-        #config.settings.lcm_diffusion_setting.negative_prompt = (
-        #    self.neg_prompt.toPlainText()
-        #)
         config.settings.lcm_diffusion_setting.lcm_lora.lcm_lora_id = (
             self.lcm_lora_id.currentText()
         )
@@ -591,17 +587,10 @@ class MainWindow(QMainWindow):
         )
 
     def store_dimension_settings(self):
-        """ These values are only needed for OpenVINO model reshape """
-        self.previous_width = (
-            self.config.settings.lcm_diffusion_setting.image_width
-        )
-        self.previous_height = (
-            self.config.settings.lcm_diffusion_setting.image_height
-        )
+        """These values are only needed for OpenVINO model reshape"""
+        self.previous_width = self.config.settings.lcm_diffusion_setting.image_width
+        self.previous_height = self.config.settings.lcm_diffusion_setting.image_height
         self.previous_model = self.config.model_id
         self.previous_num_of_images = (
             self.config.settings.lcm_diffusion_setting.number_of_images
         )
-
-
-

--- a/src/frontend/gui/app_window.py
+++ b/src/frontend/gui/app_window.py
@@ -43,6 +43,7 @@ from PyQt5.QtWidgets import (
 )
 
 from models.interface_types import InterfaceType
+from frontend.gui.base_widget import BaseWidget, ImageLabel
 
 # DPI scale fix
 QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
@@ -145,10 +146,10 @@ class MainWindow(QMainWindow):
                 LCM_DEFAULT_MODEL_OPENVINO,
             )
         )
-        self.neg_prompt.setEnabled(
-            self.config.settings.lcm_diffusion_setting.use_lcm_lora
-            or self.config.settings.lcm_diffusion_setting.use_openvino
-        )
+        #self.neg_prompt.setEnabled(
+        #    self.config.settings.lcm_diffusion_setting.use_lcm_lora
+        #    or self.config.settings.lcm_diffusion_setting.use_openvino
+        #)
         self.openvino_lcm_model_id.setEnabled(
             self.config.settings.lcm_diffusion_setting.use_openvino
         )
@@ -160,55 +161,10 @@ class MainWindow(QMainWindow):
         self.show()
 
     def create_main_tab(self):
-        self.img = QLabel("<<Image>>")
-        self.img.setAlignment(Qt.AlignCenter)
-        self.img.setFixedSize(QSize(512, 512))
-        self.vspacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
-
-        self.prompt = QTextEdit()
-        self.prompt.setPlaceholderText("A fantasy landscape")
-        self.prompt.setAcceptRichText(False)
-        self.neg_prompt = QTextEdit()
-        self.neg_prompt.setPlaceholderText("")
-        self.neg_prompt.setAcceptRichText(False)
-        self.neg_prompt_label = QLabel("Negative prompt (Set guidance scale > 1.0):")
-        self.generate = QPushButton("Generate")
-        self.generate.clicked.connect(self.text_to_image)
-        self.prompt.setFixedHeight(40)
-        self.neg_prompt.setFixedHeight(35)
-        self.browse_results = QPushButton("...")
-        self.browse_results.setFixedWidth(30)
-        self.browse_results.clicked.connect(self.on_open_results_folder)
-        self.browse_results.setToolTip("Open output folder")
-
-        hlayout = QHBoxLayout()
-        hlayout.addWidget(self.neg_prompt)
-        hlayout.addWidget(self.generate)
-        hlayout.addWidget(self.browse_results)
-
-        self.previous_img_btn = QToolButton()
-        self.previous_img_btn.setText("<")
-        self.previous_img_btn.clicked.connect(self.on_show_previous_image)
-        self.next_img_btn = QToolButton()
-        self.next_img_btn.setText(">")
-        self.next_img_btn.clicked.connect(self.on_show_next_image)
-        hlayout_nav = QHBoxLayout()
-        hlayout_nav.addWidget(self.previous_img_btn)
-        hlayout_nav.addWidget(self.img)
-        hlayout_nav.addWidget(self.next_img_btn)
-
-        vlayout = QVBoxLayout()
-        vlayout.addLayout(hlayout_nav)
-        vlayout.addItem(self.vspacer)
-        vlayout.addWidget(self.prompt)
-        vlayout.addWidget(self.neg_prompt_label)
-        vlayout.addLayout(hlayout)
-
         self.tab_widget = QTabWidget(self)
-        self.tab_main = QWidget()
+        self.tab_main = BaseWidget(self.config, self)
         self.tab_settings = QWidget()
         self.tab_about = QWidget()
-        self.tab_main.setLayout(vlayout)
         self.img2img_tab = Img2ImgWidget(self.config, self)
         self.variations_tab = ImageVariationsWidget(self.config, self)
 
@@ -490,7 +446,7 @@ class MainWindow(QMainWindow):
             self.use_lcm_lora.setEnabled(False)
             self.lcm_lora_id.setEnabled(False)
             self.base_model_id.setEnabled(False)
-            self.neg_prompt.setEnabled(True)
+            #self.neg_prompt.setEnabled(True)
             self.openvino_lcm_model_id.setEnabled(True)
             self.config.settings.lcm_diffusion_setting.use_openvino = True
         else:
@@ -498,7 +454,7 @@ class MainWindow(QMainWindow):
             self.use_lcm_lora.setEnabled(True)
             self.lcm_lora_id.setEnabled(True)
             self.base_model_id.setEnabled(True)
-            self.neg_prompt.setEnabled(False)
+            #self.neg_prompt.setEnabled(False)
             self.openvino_lcm_model_id.setEnabled(False)
             self.config.settings.lcm_diffusion_setting.use_openvino = False
 
@@ -519,13 +475,13 @@ class MainWindow(QMainWindow):
             self.lcm_model.setEnabled(False)
             self.lcm_lora_id.setEnabled(True)
             self.base_model_id.setEnabled(True)
-            self.neg_prompt.setEnabled(True)
+            #self.neg_prompt.setEnabled(True)
             self.config.settings.lcm_diffusion_setting.use_lcm_lora = True
         else:
             self.lcm_model.setEnabled(True)
             self.lcm_lora_id.setEnabled(False)
             self.base_model_id.setEnabled(False)
-            self.neg_prompt.setEnabled(False)
+            #self.neg_prompt.setEnabled(False)
             self.config.settings.lcm_diffusion_setting.use_lcm_lora = False
 
     def update_clip_skip_label(self, value):
@@ -569,74 +525,10 @@ class MainWindow(QMainWindow):
         seed_value = int(self.seed_value.text()) if use_seed else -1
         return seed_value
 
-    def generate_image(self):
-        self.config.settings.lcm_diffusion_setting.seed = self.get_seed_value()
-        self.config.settings.lcm_diffusion_setting.prompt = self.prompt.toPlainText()
-        self.config.settings.lcm_diffusion_setting.negative_prompt = (
-            self.neg_prompt.toPlainText()
-        )
-        self.config.settings.lcm_diffusion_setting.lcm_lora.lcm_lora_id = (
-            self.lcm_lora_id.currentText()
-        )
-        self.config.settings.lcm_diffusion_setting.lcm_lora.base_model_id = (
-            self.base_model_id.currentText()
-        )
-
-        if self.config.settings.lcm_diffusion_setting.use_openvino:
-            model_id = self.openvino_lcm_model_id.currentText()
-            self.config.settings.lcm_diffusion_setting.openvino_lcm_model_id = model_id
-        else:
-            model_id = self.lcm_model.currentText()
-            self.config.settings.lcm_diffusion_setting.lcm_model_id = model_id
-
-        reshape_required = False
-        if self.config.settings.lcm_diffusion_setting.use_openvino:
-            # Detect dimension change
-            reshape_required = is_reshape_required(
-                self.previous_width,
-                self.config.settings.lcm_diffusion_setting.image_width,
-                self.previous_height,
-                self.config.settings.lcm_diffusion_setting.image_height,
-                self.previous_model,
-                model_id,
-                self.previous_num_of_images,
-                self.config.settings.lcm_diffusion_setting.number_of_images,
-            )
-        self.config.settings.lcm_diffusion_setting.diffusion_task = (
-            DiffusionTask.text_to_image.value
-        )
-        images = self.context.generate_text_to_image(
-            self.config.settings,
-            reshape_required,
-            DEVICE,
-        )
-        self.image_index = 0
-        self.gen_images = []
-        for img in images:
-            im = ImageQt(img).copy()
-            pixmap = QPixmap.fromImage(im)
-            self.gen_images.append(pixmap)
-
-        if len(self.gen_images) > 1:
-            self.next_img_btn.setEnabled(True)
-            self.previous_img_btn.setEnabled(False)
-        else:
-            self.next_img_btn.setEnabled(False)
-            self.previous_img_btn.setEnabled(False)
-
-        self.show_image(self.gen_images[0])
-
-        self.previous_width = self.config.settings.lcm_diffusion_setting.image_width
-        self.previous_height = self.config.settings.lcm_diffusion_setting.image_height
-        self.previous_model = model_id
-        self.previous_num_of_images = (
-            self.config.settings.lcm_diffusion_setting.number_of_images
-        )
-
-    def text_to_image(self):
-        self.img.setText("Please wait...")
-        worker = ImageGeneratorWorker(self.generate_image)
-        self.threadpool.start(worker)
+    #def text_to_image(self):
+    #    self.img.setText("Please wait...")
+    #    worker = ImageGeneratorWorker(self.generate_image)
+    #    self.threadpool.start(worker)
 
     def closeEvent(self, event):
         self.config.settings.lcm_diffusion_setting.seed = self.get_seed_value()
@@ -662,10 +554,10 @@ class MainWindow(QMainWindow):
     def prepare_generation_settings(self, config):
         """Populate config settings with the values set by the user in the GUI"""
         config.settings.lcm_diffusion_setting.seed = self.get_seed_value()
-        config.settings.lcm_diffusion_setting.prompt = self.prompt.toPlainText()
-        config.settings.lcm_diffusion_setting.negative_prompt = (
-            self.neg_prompt.toPlainText()
-        )
+        #config.settings.lcm_diffusion_setting.prompt = self.prompt.toPlainText()
+        #config.settings.lcm_diffusion_setting.negative_prompt = (
+        #    self.neg_prompt.toPlainText()
+        #)
         config.settings.lcm_diffusion_setting.lcm_lora.lcm_lora_id = (
             self.lcm_lora_id.currentText()
         )
@@ -697,3 +589,19 @@ class MainWindow(QMainWindow):
         config.settings.lcm_diffusion_setting.diffusion_task = (
             DiffusionTask.text_to_image.value
         )
+
+    def store_dimension_settings(self):
+        """ These values are only needed for OpenVINO model reshape """
+        self.previous_width = (
+            self.config.settings.lcm_diffusion_setting.image_width
+        )
+        self.previous_height = (
+            self.config.settings.lcm_diffusion_setting.image_height
+        )
+        self.previous_model = self.config.model_id
+        self.previous_num_of_images = (
+            self.config.settings.lcm_diffusion_setting.number_of_images
+        )
+
+
+

--- a/src/frontend/gui/app_window.py
+++ b/src/frontend/gui/app_window.py
@@ -12,6 +12,7 @@ from constants import (
 from context import Context
 from frontend.gui.image_generator_worker import ImageGeneratorWorker
 from frontend.gui.image_variations_widget import ImageVariationsWidget
+from frontend.gui.upscaler_widget import UpscalerWidget
 from frontend.gui.img2img_widget import Img2ImgWidget
 from frontend.utils import (
     enable_openvino_controls,
@@ -169,11 +170,13 @@ class MainWindow(QMainWindow):
         self.tab_about = QWidget()
         self.img2img_tab = Img2ImgWidget(self.config, self)
         self.variations_tab = ImageVariationsWidget(self.config, self)
+        self.upscaler_tab = UpscalerWidget(self.config, self)
 
         # Add main window tabs here
         self.tab_widget.addTab(self.tab_main, "Text to Image")
         self.tab_widget.addTab(self.img2img_tab, "Image to Image")
         self.tab_widget.addTab(self.variations_tab, "Image Variations")
+        self.tab_widget.addTab(self.upscaler_tab, "Upscaler")
         self.tab_widget.addTab(self.tab_settings, "Settings")
         self.tab_widget.addTab(self.tab_about, "About")
 

--- a/src/frontend/gui/base_widget.py
+++ b/src/frontend/gui/base_widget.py
@@ -30,9 +30,11 @@ from PyQt5.QtCore import QSize, QThreadPool, Qt, QUrl, QBuffer
 
 import io
 from PIL import Image
+from constants import DEVICE
 from PIL.ImageQt import ImageQt
 from app_settings import AppSettings
 from urllib.parse import urlparse, unquote
+from frontend.gui.image_generator_worker import ImageGeneratorWorker
 
 
 class ImageLabel(QLabel):
@@ -73,11 +75,13 @@ class ImageLabel(QLabel):
 
 
 class BaseWidget(QWidget):
-    def __init__(self, config: AppSettings):
+    def __init__(self, config: AppSettings, parent):
         super().__init__()
         self.config = config
         self.gen_images = []
         self.image_index = 0
+        self.config = config
+        self.parent = parent
 
         # Initialize GUI widgets
         self.prev_btn = QToolButton()
@@ -98,7 +102,7 @@ class BaseWidget(QWidget):
         self.neg_prompt.setFixedHeight(35)
         self.neg_prompt.setEnabled(False)
         self.generate = QPushButton("Generate")
-        self.generate.clicked.connect(self.dummy_on_click)
+        self.generate.clicked.connect(self.generate_click)
         self.browse_results = QPushButton("...")
         self.browse_results.setFixedWidth(30)
         self.browse_results.clicked.connect(self.on_open_results_folder)
@@ -124,6 +128,20 @@ class BaseWidget(QWidget):
         vlayout.addWidget(self.neg_prompt_label)
         vlayout.addLayout(hlayout)
         self.setLayout(vlayout)
+
+    def generate_image(self):
+        self.parent.prepare_generation_settings(self.config)
+        self.config.settings.lcm_diffusion_setting.prompt = self.prompt.toPlainText()
+        self.config.settings.lcm_diffusion_setting.negative_prompt = (
+            self.neg_prompt.toPlainText()
+        )
+        images = self.parent.context.generate_text_to_image(
+            self.config.settings,
+            self.config.reshape_required,
+            DEVICE,
+        )
+        self.prepare_images(images)
+        self.after_generation()
 
     def prepare_images(self, images):
         """Prepares the generated images to be displayed in the Qt widget"""
@@ -164,8 +182,11 @@ class BaseWidget(QWidget):
             QUrl.fromLocalFile(self.config.settings.generated_images.path)
         )
 
-    def dummy_on_click(self):
-        print("Generate button clicked!")
+    def generate_click(self):
+        self.img.setText("Please wait...")
+        self.before_generation()
+        worker = ImageGeneratorWorker(self.generate_image)
+        self.parent.threadpool.start(worker)
 
     def before_generation(self):
         """Call this function before running a generation task"""
@@ -178,7 +199,7 @@ class BaseWidget(QWidget):
         self.img.setEnabled(True)
         self.generate.setEnabled(True)
         self.browse_results.setEnabled(True)
-
+        self.parent.store_dimension_settings()
 
 # Test the widget
 if __name__ == "__main__":

--- a/src/frontend/gui/base_widget.py
+++ b/src/frontend/gui/base_widget.py
@@ -129,6 +129,8 @@ class BaseWidget(QWidget):
         vlayout.addLayout(hlayout)
         self.setLayout(vlayout)
 
+        self.parent.settings_changed.connect(self.on_settings_changed)
+
     def generate_image(self):
         self.parent.prepare_generation_settings(self.config)
         self.config.settings.lcm_diffusion_setting.prompt = self.prompt.toPlainText()
@@ -200,6 +202,13 @@ class BaseWidget(QWidget):
         self.generate.setEnabled(True)
         self.browse_results.setEnabled(True)
         self.parent.store_dimension_settings()
+
+    def on_settings_changed(self):
+        self.neg_prompt.setEnabled(
+            self.config.settings.lcm_diffusion_setting.use_openvino
+            or self.config.settings.lcm_diffusion_setting.use_lcm_lora
+        )
+
 
 # Test the widget
 if __name__ == "__main__":

--- a/src/frontend/gui/image_variations_widget.py
+++ b/src/frontend/gui/image_variations_widget.py
@@ -60,19 +60,6 @@ class ImageVariationsWidget(Img2ImgWidget):
         self.prepare_images(images)
         self.after_generation()
 
-        # TODO Is it possible to move the next lines to a separate function?
-        self.parent.previous_width = (
-            self.config.settings.lcm_diffusion_setting.image_width
-        )
-        self.parent.previous_height = (
-            self.config.settings.lcm_diffusion_setting.image_height
-        )
-        self.parent.previous_model = self.config.model_id
-        self.parent.previous_num_of_images = (
-            self.config.settings.lcm_diffusion_setting.number_of_images
-        )
-
-
 # Test the widget
 if __name__ == "__main__":
     import sys

--- a/src/frontend/gui/image_variations_widget.py
+++ b/src/frontend/gui/image_variations_widget.py
@@ -60,6 +60,7 @@ class ImageVariationsWidget(Img2ImgWidget):
         self.prepare_images(images)
         self.after_generation()
 
+
 # Test the widget
 if __name__ == "__main__":
     import sys

--- a/src/frontend/gui/img2img_widget.py
+++ b/src/frontend/gui/img2img_widget.py
@@ -40,10 +40,7 @@ from frontend.gui.image_generator_worker import ImageGeneratorWorker
 
 class Img2ImgWidget(BaseWidget):
     def __init__(self, config: AppSettings, parent):
-        super().__init__(config)
-        self.config = config
-        self.parent = parent
-        self.generate.clicked.connect(self.img2img_click)
+        super().__init__(config, parent)
 
         # Create init image selection widgets
         self.img_label = QLabel("Init image:")
@@ -72,12 +69,6 @@ class Img2ImgWidget(BaseWidget):
         self.layout().addLayout(hlayout)
         self.layout().addWidget(self.strength_label)
         self.layout().addWidget(self.strength)
-
-    def img2img_click(self):
-        self.img.setText("Please wait...")
-        self.before_generation()
-        worker = ImageGeneratorWorker(self.generate_image)
-        self.parent.threadpool.start(worker)
 
     def browse_click(self):
         filename = self.show_file_selection_dialog()
@@ -113,6 +104,7 @@ class Img2ImgWidget(BaseWidget):
         super().after_generation()
         self.img_browse.setEnabled(True)
         self.img_path.setEnabled(True)
+        
 
     def generate_image(self):
         self.parent.prepare_generation_settings(self.config)
@@ -135,18 +127,6 @@ class Img2ImgWidget(BaseWidget):
         )
         self.prepare_images(images)
         self.after_generation()
-
-        # TODO Is it possible to move the next lines to a separate function?
-        self.parent.previous_width = (
-            self.config.settings.lcm_diffusion_setting.image_width
-        )
-        self.parent.previous_height = (
-            self.config.settings.lcm_diffusion_setting.image_height
-        )
-        self.parent.previous_model = self.config.model_id
-        self.parent.previous_num_of_images = (
-            self.config.settings.lcm_diffusion_setting.number_of_images
-        )
 
     def update_strength_label(self, value):
         val = round(int(value) / 10, 1)

--- a/src/frontend/gui/img2img_widget.py
+++ b/src/frontend/gui/img2img_widget.py
@@ -104,7 +104,6 @@ class Img2ImgWidget(BaseWidget):
         super().after_generation()
         self.img_browse.setEnabled(True)
         self.img_path.setEnabled(True)
-        
 
     def generate_image(self):
         self.parent.prepare_generation_settings(self.config)

--- a/src/frontend/gui/upscaler_widget.py
+++ b/src/frontend/gui/upscaler_widget.py
@@ -1,0 +1,124 @@
+from PyQt5.QtWidgets import (
+    QWidget,
+    QPushButton,
+    QHBoxLayout,
+    QVBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QSlider,
+    QTabWidget,
+    QSpacerItem,
+    QSizePolicy,
+    QComboBox,
+    QCheckBox,
+    QTextEdit,
+    QToolButton,
+    QFileDialog,
+    QApplication,
+    QRadioButton,
+    QFrame,
+)
+from PyQt5 import QtWidgets, QtCore
+from PyQt5.QtGui import QPixmap, QDesktopServices, QDragEnterEvent, QDropEvent
+from PyQt5.QtCore import QSize, QThreadPool, Qt, QUrl, QBuffer
+
+import io
+from PIL import Image
+from constants import DEVICE
+from PIL.ImageQt import ImageQt
+from app_settings import AppSettings
+from urllib.parse import urlparse, unquote
+from backend.models.upscale import UpscaleMode
+from backend.upscale.upscaler import upscale_image
+from frontend.gui.img2img_widget import Img2ImgWidget
+from paths import FastStableDiffusionPaths, join_paths
+from backend.models.lcmdiffusion_setting import DiffusionTask
+from frontend.gui.image_generator_worker import ImageGeneratorWorker
+from frontend.webui.image_variations_ui import generate_image_variations
+
+
+class UpscalerWidget(Img2ImgWidget):
+    scale_factor = 2.0
+
+    def __init__(self, config: AppSettings, parent):
+        super().__init__(config, parent)
+        # Hide prompt and negative prompt widgets
+        self.prompt.hide()
+        self.neg_prompt.hide()
+        # self.neg_prompt.deleteLater()
+        # Create upscaler widgets
+        self.edsr_button = QRadioButton("EDSR", self)
+        self.edsr_button.toggled.connect(self.on_mode_change)
+        self.edsr_button.toggle()
+        self.sd_button = QRadioButton("SD", self)
+        self.sd_button.toggled.connect(self.on_mode_change)
+        self.aura_button = QRadioButton("AURA-SR", self)
+        self.aura_button.toggled.connect(self.on_mode_change)
+        self.aura_button.setEnabled(False)
+        self.aura_button.setToolTip("AURA-SR upscale not implemented")
+
+        self.neg_prompt_label.setText("Upscale mode (2x):")
+        # Create upscaler buttons layout
+        hlayout = QHBoxLayout()
+        hlayout.addWidget(self.edsr_button)
+        hlayout.addWidget(self.sd_button)
+        hlayout.addWidget(self.aura_button)
+        # Can't use a layout with replaceWidget(), so the layout is assigned
+        # to a dummy widget used to replace the negative prompt button and
+        # obtain the desired GUI design
+        self.container = QWidget()
+        self.container.setLayout(hlayout)
+        self.layout().replaceWidget(self.neg_prompt, self.container)
+
+    def generate_image(self):
+        self.parent.prepare_generation_settings(self.config)
+        self.config.settings.lcm_diffusion_setting.init_image = Image.open(
+            self.img_path.text()
+        )
+        self.config.settings.lcm_diffusion_setting.strength = self.strength.value() / 10
+        upscaled_filepath = FastStableDiffusionPaths.get_upscale_filepath(
+            None,
+            self.scale_factor,
+            self.config.settings.generated_images.format,
+        )
+
+        images = upscale_image(
+            context=self.parent.context,
+            src_image_path=self.img_path.text(),
+            dst_image_path=upscaled_filepath,
+            upscale_mode=self.upscale_mode,
+            strength=self.strength.value() / 10,
+        )
+        self.prepare_images(images)
+        self.after_generation()
+
+    def before_generation(self):
+        super().before_generation()
+        self.container.setEnabled(False)
+
+    def after_generation(self):
+        super().after_generation()
+        self.container.setEnabled(True)
+        # TODO For some reason, if init_image is not set to None, saving settings
+        # when closing the main window will fail, even though the save() method
+        # explicitly sets init_image to None?
+        self.config.settings.lcm_diffusion_setting.init_image = None
+
+    def on_mode_change(self):
+        if self.edsr_button.isChecked():
+            self.upscale_mode = UpscaleMode.normal.value
+        elif self.sd_button.isChecked():
+            self.upscale_mode = UpscaleMode.sd_upscale.value
+        else:
+            self.upscale_mode = UpscaleMode.aura_sr.value
+
+
+# Test the widget
+if __name__ == "__main__":
+    import sys
+
+    app = QApplication(sys.argv)
+    widget = ImageVariationsWidget(None, None)
+    widget.show()
+    app.exec()

--- a/src/frontend/gui/upscaler_widget.py
+++ b/src/frontend/gui/upscaler_widget.py
@@ -48,6 +48,7 @@ class UpscalerWidget(Img2ImgWidget):
         self.neg_prompt.hide()
         # self.neg_prompt.deleteLater()
         # Create upscaler widgets
+        self.generate.setText("Upscale")
         self.edsr_button = QRadioButton("EDSR", self)
         self.edsr_button.toggled.connect(self.on_mode_change)
         self.edsr_button.toggle()
@@ -55,10 +56,8 @@ class UpscalerWidget(Img2ImgWidget):
         self.sd_button.toggled.connect(self.on_mode_change)
         self.aura_button = QRadioButton("AURA-SR", self)
         self.aura_button.toggled.connect(self.on_mode_change)
-        self.aura_button.setEnabled(False)
-        self.aura_button.setToolTip("AURA-SR upscale not implemented")
 
-        self.neg_prompt_label.setText("Upscale mode (2x):")
+        self.neg_prompt_label.setText("Upscale mode (2x) | AURA-SR (4x):")
         # Create upscaler buttons layout
         hlayout = QHBoxLayout()
         hlayout.addWidget(self.edsr_button)
@@ -106,12 +105,14 @@ class UpscalerWidget(Img2ImgWidget):
         self.config.settings.lcm_diffusion_setting.init_image = None
 
     def on_mode_change(self):
+        self.scale_factor = 2.0
         if self.edsr_button.isChecked():
             self.upscale_mode = UpscaleMode.normal.value
         elif self.sd_button.isChecked():
             self.upscale_mode = UpscaleMode.sd_upscale.value
         else:
             self.upscale_mode = UpscaleMode.aura_sr.value
+            self.scale_factor = 4.0
 
 
 # Test the widget

--- a/src/frontend/gui/upscaler_widget.py
+++ b/src/frontend/gui/upscaler_widget.py
@@ -47,8 +47,10 @@ class UpscalerWidget(Img2ImgWidget):
         self.prompt.hide()
         self.neg_prompt.hide()
         # self.neg_prompt.deleteLater()
-        # Create upscaler widgets
+        self.strength_label.hide()
+        self.strength.hide()
         self.generate.setText("Upscale")
+        # Create upscaler widgets
         self.edsr_button = QRadioButton("EDSR", self)
         self.edsr_button.toggled.connect(self.on_mode_change)
         self.edsr_button.toggle()
@@ -87,7 +89,7 @@ class UpscalerWidget(Img2ImgWidget):
             src_image_path=self.img_path.text(),
             dst_image_path=upscaled_filepath,
             upscale_mode=self.upscale_mode,
-            strength=self.strength.value() / 10,
+            strength=0.1,
         )
         self.prepare_images(images)
         self.after_generation()


### PR DESCRIPTION
In this PR I added the Upscaler tab to the Qt GUI. Please note that I currently don't have the AURA-SR model installed, nor enough HDD space to download it so I can't test it and as such it's currently disabled. It should work but I have no way to try it.
Also in this PR, I finally removed the duplicated code in _app_window.py_ for the txt2img workflow and replaced it with the corresponding code provided by an instance of the widget class defined in _base_widget.py_. Hopefully nothing broke with these changes.

Will try to continue working on adding to the Qt version the remaining options supported by the CLI and WebUI versions.