### PR TITLE
Enable SDXL model loading from safetensor files

### DIFF
--- a/src/backend/pipelines/lcm.py
+++ b/src/backend/pipelines/lcm.py
@@ -5,6 +5,7 @@ from diffusers import (
     UNet2DConditionModel,
     LCMScheduler,
     StableDiffusionPipeline,
+    StableDiffusionXLPipeline
 )
 import torch
 from backend.tiny_autoencoder import get_tiny_autoencoder_repo_id


### PR DESCRIPTION
Per [issue 274](https://github.com/rupeshs/fastsdcpu/issues/274), fastsdcpu cannot load SDXL models from safetensor files.  I reviewed the code and saw that the reason for this was the lack of a diffusers "from_single_file" method for SDXL.

The diffusers library now has this method, so I used it.

I am not familiar enough with safetensor files to do anything more sophisticated than "if the model has xl in the name, use the XL pipeline" but if anyone has an actual smart way of differentiating SDXL from SD1.5, feel free to use that instead.

Also, the SDXL pipeline does not appear to support whatever safety_checker parameters you were passing to the StableDiffusion pipeline, so I had to remove it.