### PR TITLE
Add LoRA and ControlNet tabs to the Qt GUI

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -357,7 +357,7 @@ else:
     config.lcm_diffusion_setting.lora.enabled = False
     config.lcm_diffusion_setting.lora.path = args.lora
     config.lcm_diffusion_setting.lora.weight = args.lora_weight
-    config.lcm_diffusion_setting.lora.fuse = True
+    config.lcm_diffusion_setting.lora.fuse = False
     if config.lcm_diffusion_setting.lora.path:
         config.lcm_diffusion_setting.lora.enabled = True
     if args.usejpeg:

--- a/src/backend/lcm_text_to_image.py
+++ b/src/backend/lcm_text_to_image.py
@@ -6,6 +6,7 @@ import random
 import numpy as np
 import torch
 from backend.device import is_openvino_device
+from backend.lora import reset_active_lora_weights
 from backend.controlnet import (
     load_controlnet_adapters,
     update_controlnet_arguments,
@@ -274,6 +275,7 @@ class LCMTextToImage:
                     gc.collect()
 
                 controlnet_args = load_controlnet_adapters(lcm_diffusion_setting)
+                reset_active_lora_weights()
                 if use_lora:
                     print(
                         f"***** Init LCM-LoRA pipeline - {lcm_lora.base_model_id} *****"

--- a/src/backend/lora.py
+++ b/src/backend/lora.py
@@ -48,10 +48,7 @@ def load_lora_weight(
     global _loaded_loras
     global _current_pipeline
     if pipeline != _current_pipeline:
-        for lora in _loaded_loras:
-            del lora
-        del _loaded_loras
-        _loaded_loras = []
+        reset_active_lora_weights()
         _current_pipeline = pipeline
 
     current_lora = _lora_info(
@@ -99,6 +96,17 @@ def get_active_lora_weights():
             )
         )
     return active_loras
+
+
+# Clears the global list of active LoRA weights; this method doesn't
+# actually remove the active LoRA weights from the current generation
+# pipeline and it's only meant to be called when rebuilding the pipeline
+def reset_active_lora_weights():
+    global _loaded_loras
+    for lora in _loaded_loras:
+        del lora
+    del _loaded_loras
+    _loaded_loras = []
 
 
 # This function receives a pipeline, an lcm_diffusion_setting object and

--- a/src/frontend/gui/app_window.py
+++ b/src/frontend/gui/app_window.py
@@ -40,7 +40,9 @@ from PyQt5.QtWidgets import (
 )
 
 from models.interface_types import InterfaceType
-from frontend.gui.base_widget import BaseWidget
+from frontend.gui.base_widget import BaseWidget, ImageLabel
+from frontend.gui.lora_widget import LoraModelsWidget
+from frontend.gui.controlnet_widget import ControlNetWidget
 
 # DPI scale fix
 QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
@@ -161,12 +163,15 @@ class MainWindow(QMainWindow):
 
     def create_main_tab(self):
         self.tab_widget = QTabWidget(self)
+        self.tab_widget.currentChanged.connect(self.on_current_tab_changed)
         self.tab_main = BaseWidget(self.config, self)
         self.tab_settings = QWidget()
         self.tab_about = QWidget()
         self.img2img_tab = Img2ImgWidget(self.config, self)
         self.variations_tab = ImageVariationsWidget(self.config, self)
         self.upscaler_tab = UpscalerWidget(self.config, self)
+        self.loras_tab = LoraModelsWidget(self.config, self)
+        self.controlnet_tab = ControlNetWidget(self.config, self)
 
         # Add main window tabs here
         self.tab_widget.addTab(self.tab_main, "Text to Image")
@@ -174,6 +179,8 @@ class MainWindow(QMainWindow):
         self.tab_widget.addTab(self.variations_tab, "Image Variations")
         self.tab_widget.addTab(self.upscaler_tab, "Upscaler")
         self.tab_widget.addTab(self.tab_settings, "Settings")
+        self.tab_widget.addTab(self.loras_tab, "LoRA Models")
+        self.tab_widget.addTab(self.controlnet_tab, "ControlNet")
         self.tab_widget.addTab(self.tab_about, "About")
 
         self.setCentralWidget(self.tab_widget)
@@ -238,7 +245,9 @@ class MainWindow(QMainWindow):
         self.width_value = QLabel("Width :")
         self.width = QComboBox(self)
         self.width.addItem("256")
+        self.width.addItem("384")
         self.width.addItem("512")
+        self.width.addItem("640")
         self.width.addItem("768")
         self.width.addItem("1024")
         self.width.setCurrentText("512")
@@ -247,7 +256,9 @@ class MainWindow(QMainWindow):
         self.height_value = QLabel("Height :")
         self.height = QComboBox(self)
         self.height.addItem("256")
+        self.height.addItem("384")
         self.height.addItem("512")
+        self.height.addItem("640")
         self.height.addItem("768")
         self.height.addItem("1024")
         self.height.setCurrentText("512")
@@ -591,3 +602,7 @@ class MainWindow(QMainWindow):
         self.previous_num_of_images = (
             self.config.settings.lcm_diffusion_setting.number_of_images
         )
+
+    def on_current_tab_changed(self, index):
+        if index == 5:  # LoRA models tab
+            self.loras_tab.reset_active_lora_widgets()

--- a/src/frontend/gui/base_widget.py
+++ b/src/frontend/gui/base_widget.py
@@ -17,46 +17,16 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from app_settings import AppSettings
+import io
+from PIL import Image
 from constants import DEVICE
+from state import get_context
+from PIL.ImageQt import ImageQt
+from app_settings import AppSettings
+from urllib.parse import urlparse, unquote
+from models.interface_types import InterfaceType
 from frontend.gui.image_generator_worker import ImageGeneratorWorker
-
-
-class ImageLabel(QLabel):
-    """Defines a simple QLabel widget"""
-
-    changed = QtCore.pyqtSignal()
-
-    def __init__(self, text: str):
-        super().__init__(text)
-        self.setAlignment(Qt.AlignCenter)
-        self.resize(512, 512)
-        self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
-        self.sizeHint = QSize(512, 512)
-        self.setAcceptDrops(False)
-
-    def show_image(self, pixmap: QPixmap = None):
-        """Updates the widget pixamp"""
-        if pixmap == None or pixmap.isNull():
-            return
-        self.current_pixmap = pixmap
-        self.changed.emit()
-
-        # Resize the pixmap to the widget dimensions
-        image_width = self.current_pixmap.width()
-        image_height = self.current_pixmap.height()
-        if image_width > 512 or image_height > 512:
-            new_width = 512 if image_width > 512 else image_width
-            new_height = 512 if image_height > 512 else image_height
-            self.setPixmap(
-                self.current_pixmap.scaled(
-                    new_width,
-                    new_height,
-                    Qt.KeepAspectRatio,
-                )
-            )
-        else:
-            self.setPixmap(self.current_pixmap)
+from frontend.gui.common_widgets import ImageLabel
 
 
 class BaseWidget(QWidget):
@@ -122,7 +92,7 @@ class BaseWidget(QWidget):
         self.config.settings.lcm_diffusion_setting.negative_prompt = (
             self.neg_prompt.toPlainText()
         )
-        images = self.parent.context.generate_text_to_image(
+        images = get_context(InterfaceType.GUI).generate_text_to_image(
             self.config.settings,
             self.config.reshape_required,
             DEVICE,

--- a/src/frontend/gui/common_widgets.py
+++ b/src/frontend/gui/common_widgets.py
@@ -1,0 +1,139 @@
+from os import path
+from PIL import Image
+from urllib.parse import urlparse, unquote
+from PyQt5 import QtCore
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QHBoxLayout,
+    QVBoxLayout,
+    QGridLayout,
+    QPushButton,
+    QRadioButton,
+    QButtonGroup,
+    QSlider,
+    QLabel,
+    QFrame,
+    QComboBox,
+    QCheckBox,
+    QWidget,
+    QSizePolicy,
+    QMessageBox,
+)
+from PyQt5.QtCore import QSize
+from PyQt5.QtGui import QPixmap, QDesktopServices, QDragEnterEvent, QDropEvent
+
+
+class LabeledSlider(QWidget):
+    """A simple QSlider and QLabel combo for displaying the slider value;
+    it holds both an _int_ and _float_ representation of the slider value
+    for convenience, the value to display is determined by the
+    _use_float_value_ initialization argument.
+    """
+
+    valueChanged = QtCore.pyqtSignal(int, float)
+
+    def __init__(self, use_float_value=False):
+        super().__init__()
+        self.use_float_value = use_float_value
+        self._label = QLabel("0")
+        if use_float_value:
+            self._label.setText("0.00")
+        self._slider = QSlider(orientation=Qt.Orientation.Horizontal)
+        self._slider.setMaximum(20)
+        self._slider.setMinimum(0)
+        self._slider.setValue(0)
+        self._slider.setTickInterval(1)
+        self._slider.setSingleStep(1)
+        self._slider.valueChanged.connect(self.onSliderChanged)
+        hlayout = QHBoxLayout()
+        hlayout.addWidget(self._slider)
+        hlayout.addWidget(self._label)
+        self.setLayout(hlayout)
+
+    def onSliderChanged(self, value):
+        if self.use_float_value:
+            self._label.setText("%.2f" % (value / 20.0))
+        else:
+            self._label.setText("%d" % (value))
+        self.valueChanged.emit(value, value / 20.0)
+
+    def setValue(self, value):
+        if self.use_float_value:
+            self._slider.setValue(int(value * 20))
+        else:
+            self._slider.setValue(value)
+
+    def getValue(self):
+        if self.use_float_value:
+            return self._slider.value() / 20.0
+        else:
+            return self._slider.value()
+
+
+class ImageLabel(QLabel):
+    """A simple QLabel widget for displaying an image; the label image
+    can be updated either by calling the _show_image()_ method or by
+    dragging an image into the widget area if the label is set to
+    accept drag and drop, which is set to _False_ by default.
+    """
+
+    changed = QtCore.pyqtSignal()
+
+    def __init__(self, text: str, width=512, height=512):
+        super().__init__(text)
+        self.setAlignment(Qt.AlignCenter)
+        self.resize(width, height)
+        self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
+        self.sizeHint = QSize(width, height)
+        self.width = width
+        self.height = height
+        self.setAcceptDrops(False)
+
+    def show_image(self, pixmap: QPixmap = None):
+        """Updates the widget pixamp"""
+        if pixmap == None or pixmap.isNull():
+            return
+        self.current_pixmap = pixmap
+        self.changed.emit()
+
+        # Resize the pixmap to the widget dimensions
+        image_width = self.current_pixmap.width()
+        image_height = self.current_pixmap.height()
+        if image_width > self.width or image_height > self.height:
+            new_width = self.width if image_width > self.width else image_width
+            new_height = self.height if image_height > self.height else image_height
+            self.setPixmap(
+                self.current_pixmap.scaled(
+                    new_width,
+                    new_height,
+                    Qt.KeepAspectRatio,
+                )
+            )
+        else:
+            self.setPixmap(self.current_pixmap)
+
+    def dragEnterEvent(self, event: QDragEnterEvent):
+        if event.mimeData().hasFormat("text/plain"):
+            event.acceptProposedAction()
+
+    def dropEvent(self, event: QDropEvent):
+        event.acceptProposedAction()
+        self.path = unquote(urlparse(event.mimeData().text()).path)
+        pixmap = QPixmap(self.path)
+        self.show_image(pixmap)
+        self.update()
+
+
+# Test the widget
+if __name__ == "__main__":
+    import sys
+
+    app = QApplication(sys.argv)
+    window = QMainWindow()
+    window.resize(640, 480)
+    window.layout().addWidget(LabeledSlider(True))
+    window.layout().addWidget(ImageLabel("Hello world!", 128, 128))
+    window.show()
+    app.exec()

--- a/src/frontend/gui/controlnet_widget.py
+++ b/src/frontend/gui/controlnet_widget.py
@@ -1,0 +1,173 @@
+from os import path
+from PIL import Image
+from urllib.parse import urlparse, unquote
+from PyQt5 import QtCore
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QVBoxLayout,
+    QGridLayout,
+    QPushButton,
+    QRadioButton,
+    QButtonGroup,
+    QSlider,
+    QLabel,
+    QFrame,
+    QComboBox,
+    QCheckBox,
+    QWidget,
+    QSizePolicy,
+    QMessageBox,
+)
+from PyQt5.QtCore import QSize
+from app_settings import AppSettings
+from PyQt5.QtGui import QPixmap, QDesktopServices, QDragEnterEvent, QDropEvent
+from paths import FastStableDiffusionPaths
+from backend.models.lcmdiffusion_setting import ControlNetSetting
+from backend.annotators.image_control_factory import ImageControlFactory
+from frontend.gui.common_widgets import LabeledSlider, ImageLabel
+
+if __name__ != "__main__":
+    from state import get_settings, get_context
+    from models.interface_types import InterfaceType
+    from backend.lora import get_lora_models
+
+    app_settings = get_settings()
+
+
+_controlnet_models_map = {}
+_current_controlnet_image = None
+_current_controlnet_weight = 0.0
+_current_controlnet_adapter = ""
+_current_controlnet_enabled = False
+
+
+class ControlNetWidget(QWidget):
+    def __init__(self, config: AppSettings, parent):
+        super().__init__()
+        self.parent = parent
+        global _controlnet_models_map
+        global _current_controlnet_adapter
+        _controlnet_models_map = {}
+        if config != None:
+            _controlnet_models_map = get_lora_models(
+                config.settings.lcm_diffusion_setting.dirs["controlnet"]
+            )
+        if len(_controlnet_models_map) > 0:
+            _current_controlnet_adapter = list(_controlnet_models_map.keys())[0]
+        self.enabled_checkbox = QCheckBox("Enable ControlNet")
+        self.enabled_checkbox.stateChanged.connect(self.on_enable_changed)
+        self.models_combobox = QComboBox()
+        self.models_combobox.addItems(_controlnet_models_map.keys())
+        self.models_combobox.setToolTip(
+            "<p style='white-space:pre'>Place LoRA models in the <b>controlnet_models</b> folder</p>"
+        )
+        self.models_combobox.setEnabled(False)
+        self.models_combobox.currentTextChanged.connect(self.on_combo_changed)
+        self.weight_slider = LabeledSlider(True)
+        self.weight_slider.setEnabled(False)
+        self.weight_slider.valueChanged.connect(self.on_weight_changed)
+        self.image_label = ImageLabel("Drag and drop control image here", 256, 256)
+        self.image_label.setMinimumSize(QSize(256, 256))
+        self.image_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.image_label.setFrameShape(QFrame.Box)
+        self.image_label.setAcceptDrops(True)
+        self.image_label.setEnabled(False)
+        self.image_label.changed.connect(self.on_image_changed)
+
+        radio_buttons_layout = QHBoxLayout()
+        self.radio_buttons_group = QButtonGroup()
+        radio_buttons_text = [
+            "Canny",
+            "Depth",
+            "Lineart",
+            "MLSD",
+            "NormalBAE",
+            "Pose",
+            "SoftEdge",
+            "Shuffle",
+            "None",
+        ]
+        for text in radio_buttons_text:
+            radio_button = QRadioButton(text)
+            radio_buttons_layout.addWidget(radio_button)
+            self.radio_buttons_group.addButton(radio_button)
+        radio_button.setChecked(True)
+
+        hlayout = QHBoxLayout()
+        hlayout.addWidget(self.models_combobox)
+        hlayout.addWidget(self.weight_slider)
+        hlayout.addWidget(self.image_label)
+        vlayout = QVBoxLayout()
+        vlayout.addWidget(self.enabled_checkbox, 5)
+        vlayout.addLayout(hlayout)
+        vlayout.addLayout(radio_buttons_layout)
+        vlayout.addStretch(80)
+        self.setLayout(vlayout)
+
+    def on_image_changed(self):
+        global _current_controlnet_image
+        _current_controlnet_image = Image.open(self.image_label.path)
+        selected_preprocessor = self.radio_buttons_group.checkedButton().text()
+        if selected_preprocessor != "None":
+            image_control_factory = ImageControlFactory()
+            control = image_control_factory.create_control(selected_preprocessor)
+            _current_controlnet_image = control.get_control_image(
+                _current_controlnet_image
+            )
+        self.update_controlnet_settings()
+
+    def on_enable_changed(self, state: int):
+        global _current_controlnet_enabled
+        _current_controlnet_enabled = False
+        if state == Qt.Checked:
+            _current_controlnet_enabled = True
+        self.models_combobox.setEnabled(_current_controlnet_enabled)
+        self.weight_slider.setEnabled(_current_controlnet_enabled)
+        self.image_label.setEnabled(_current_controlnet_enabled)
+        self.update_controlnet_settings()
+
+    def on_combo_changed(self, text: str):
+        global _current_controlnet_adapter
+        _current_controlnet_adapter = text
+        self.update_controlnet_settings()
+
+    def on_weight_changed(self, value: int, valuef: float):
+        global _current_controlnet_weight
+        _current_controlnet_weight = valuef
+        self.update_controlnet_settings()
+
+    def update_controlnet_settings(self):
+        # Code for testing the GUI; ignore when running FastSD CPU
+        if __name__ == "__main__":
+            return
+
+        global _current_controlnet_enabled
+        global _current_controlnet_adapter
+        global _current_controlnet_weight
+        global _current_controlnet_image
+        global _controlnet_models_map
+        settings = app_settings.settings.lcm_diffusion_setting
+        if not _current_controlnet_enabled:
+            settings.controlnet.enabled = False
+        else:
+            settings.controlnet.enabled = True
+            settings.controlnet.adapter_path = _controlnet_models_map[
+                _current_controlnet_adapter
+            ]
+            settings.controlnet.conditioning_scale = _current_controlnet_weight
+            settings.controlnet._control_image = _current_controlnet_image
+        # Currently, every change made to the ControlNet settings will
+        # trigger a pipeline rebuild, this can probably be improved
+        settings.rebuild_pipeline = True
+
+
+# Test the widget
+if __name__ == "__main__":
+    import sys
+
+    app = QApplication(sys.argv)
+    widget = ControlNetWidget(None, None)
+    widget.show()
+    app.exec()

--- a/src/frontend/gui/lora_widget.py
+++ b/src/frontend/gui/lora_widget.py
@@ -1,0 +1,203 @@
+from os import path
+from PIL import Image
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QVBoxLayout,
+    QGridLayout,
+    QPushButton,
+    QSlider,
+    QLabel,
+    QFrame,
+    QComboBox,
+    QWidget,
+    QSizePolicy,
+    QMessageBox,
+)
+from backend.lora import (
+    get_lora_models,
+    get_active_lora_weights,
+    update_lora_weights,
+    load_lora_weight,
+)
+from frontend.gui.common_widgets import LabeledSlider
+from app_settings import AppSettings
+from paths import FastStableDiffusionPaths
+
+if __name__ != "__main__":
+    from state import get_settings, get_context
+    from models.interface_types import InterfaceType
+
+    app_settings = get_settings()
+
+
+_MAX_LORA_WEIGHTS = 5
+_current_lora_count = 0
+_active_lora_widgets = []
+
+
+# This is a simple widget for displaying the loaded LoRAs name and weight
+class _LoraWidget(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.name_label = QLabel()
+        self.strength_slider = LabeledSlider(True)
+        hlayout = QHBoxLayout()
+        hlayout.addWidget(self.name_label)
+        hlayout.addWidget(self.strength_slider)
+        self.setLayout(hlayout)
+
+    def setValues(self, name: str, weight: float):
+        self.name_label.setText(name)
+        self.strength_slider.setValue(weight)
+
+    def getValues(self):
+        return (self.name_label.text(), self.strength_slider.getValue())
+
+
+class LoraModelsWidget(QWidget):
+    def __init__(self, config: AppSettings, parent):
+        super().__init__()
+        self.parent = parent
+        lora_models_map = {}
+        if config != None:
+            lora_models_map = get_lora_models(
+                config.settings.lcm_diffusion_setting.lora.models_dir
+            )
+        self.models_combobox = QComboBox()
+        self.models_combobox.addItems(lora_models_map.keys())
+        self.models_combobox.setToolTip(
+            "<p style='white-space:pre'>Place LoRA models in the <b>lora_models</b> folder</p>"
+        )
+        self.weight_slider = LabeledSlider(True)
+        self.load_button = QPushButton("Load selected LoRA")
+        self.load_button.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
+        self.load_button.clicked.connect(self.on_load_lora)
+        self.loaded_label = QLabel("Loaded LoRA models:")
+        self.update_button = QPushButton("Update LoRA weights")
+        self.update_button.clicked.connect(self.on_update_weights)
+        self.separator = QLabel()
+        self.separator.setFrameShape(QFrame.HLine)
+
+        glayout = QGridLayout()
+        glayout.setVerticalSpacing(0)
+        glayout.addWidget(QLabel("LoRA model:"), 0, 0)
+        glayout.addWidget(
+            QLabel(
+                "Initial LoRA weight:",
+            ),
+            0,
+            1,
+        )
+        glayout.addWidget(self.models_combobox, 1, 0)
+        glayout.addWidget(self.weight_slider, 1, 1)
+        glayout.addWidget(self.load_button, 0, 2, 2, 1)
+        hlayout = QHBoxLayout()
+        hlayout.addWidget(self.loaded_label)
+        hlayout.addWidget(self.update_button)
+        vlayout = QVBoxLayout()
+        vlayout.addLayout(glayout, 10)
+        vlayout.addWidget(self.separator, 1)
+        vlayout.addLayout(hlayout, 10)
+        vlayout.addStretch(80)
+        self.setLayout(vlayout)
+
+    def on_load_lora(self):
+        # Code for testing the GUI; ignore when running FastSD CPU
+        if __name__ == "__main__":
+            self.layout().insertWidget(3, _LoraWidget())
+            return
+        # End of code for testing the GUI
+
+        global _current_lora_count
+        global _active_lora_widgets
+        if app_settings == None or _current_lora_count >= _MAX_LORA_WEIGHTS:
+            return
+        if app_settings.settings.lcm_diffusion_setting.use_openvino:
+            QMessageBox().information(
+                self.parent,
+                "Error",
+                "LoRA suppport is currently not implemented for OpenVINO.",
+            )
+            return
+        lora_models_map = get_lora_models(
+            app_settings.settings.lcm_diffusion_setting.lora.models_dir
+        )
+
+        # Load a new LoRA
+        settings = app_settings.settings.lcm_diffusion_setting
+        settings.lora.fuse = False
+        settings.lora.enabled = False
+        current_lora = self.models_combobox.currentText()
+        current_weight = self.weight_slider.getValue()
+        print(f"Selected Lora Model :{current_lora}")
+        print(f"Lora weight :{current_weight}")
+        settings.lora.path = lora_models_map[current_lora]
+        settings.lora.weight = current_weight
+        if not path.exists(settings.lora.path):
+            QMessageBox.information(self.parent, "Error", "Invalid LoRA model path!")
+            return
+        pipeline = get_context(InterfaceType.GUI).lcm_text_to_image.pipeline
+        if not pipeline:
+            QMessageBox.information(
+                self.parent,
+                "Error",
+                "Pipeline not initialized. Please generate an image first.",
+            )
+            return
+        settings.lora.enabled = True
+        load_lora_weight(
+            get_context(InterfaceType.GUI).lcm_text_to_image.pipeline,
+            settings,
+        )
+        lora_widget = _LoraWidget()
+        lora_widget.setValues(current_lora, current_weight)
+        self.layout().insertWidget(3, lora_widget)
+        _active_lora_widgets.append(lora_widget)
+        _current_lora_count += 1
+
+    def on_update_weights(self):
+        update_weights = []
+        active_weights = get_active_lora_weights()
+        if not len(active_weights):
+            # QMessageBox.information(self.parent, "Error", "No active LoRAs, first you need to load LoRA model")
+            return
+        global _active_lora_widgets
+        for idx, lora in enumerate(active_weights):
+            update_weights.append(
+                (
+                    lora[0],
+                    _active_lora_widgets[idx].getValues()[1],
+                )
+            )
+        if len(update_weights) > 0:
+            update_lora_weights(
+                get_context(InterfaceType.GUI).lcm_text_to_image.pipeline,
+                app_settings.settings.lcm_diffusion_setting,
+                update_weights,
+            )
+            print(_active_lora_widgets)
+
+    def reset_active_lora_widgets(self):
+        # This code assumes that the only time when the active LoRA weights count
+        # is different from the current LoRA GUI widgets count is after a pipeline
+        # rebuild, when the active LoRA widgets count will be zero, so all LoRA GUI
+        # widgets are simply removed with no further action
+        global _current_lora_count
+        global _active_lora_widgets
+        if len(get_active_lora_weights()) != _current_lora_count:
+            for lora_widget in _active_lora_widgets:
+                self.layout().removeWidget(lora_widget)
+            _current_lora_count = 0
+            _active_lora_widgets = []
+
+
+# Test the widget
+if __name__ == "__main__":
+    import sys
+
+    app = QApplication(sys.argv)
+    widget = LoraModelsWidget(None, None)
+    widget.show()
+    app.exec()


### PR DESCRIPTION
This PR adds LoRA and ControlNet tabs to the Qt GUI. LoRA and ControlNet are currently only supported for SD 1.5.