### PR TITLE
Fix double RAM usage in Qt GUI

### DIFF
--- a/src/frontend/gui/base_widget.py
+++ b/src/frontend/gui/base_widget.py
@@ -92,7 +92,7 @@ class BaseWidget(QWidget):
         self.config.settings.lcm_diffusion_setting.negative_prompt = (
             self.neg_prompt.toPlainText()
         )
-        images = get_context(InterfaceType.GUI).generate_text_to_image(
+        images = self.parent.context.generate_text_to_image(
             self.config.settings,
             self.config.reshape_required,
             DEVICE,
@@ -151,6 +151,7 @@ class BaseWidget(QWidget):
 
     def before_generation(self):
         """Call this function before running a generation task"""
+        self.config = self.parent.config
         self.img.setEnabled(False)
         self.generate.setEnabled(False)
         self.browse_results.setEnabled(False)

--- a/src/frontend/gui/image_variations_widget.py
+++ b/src/frontend/gui/image_variations_widget.py
@@ -1,4 +1,5 @@
 from PIL import Image
+from constants import DEVICE
 from PyQt5.QtWidgets import QApplication
 
 from app_settings import AppSettings
@@ -27,9 +28,10 @@ class ImageVariationsWidget(Img2ImgWidget):
         )
         self.config.settings.lcm_diffusion_setting.strength = self.strength.value() / 10
 
-        images = generate_image_variations(
-            self.config.settings.lcm_diffusion_setting.init_image,
-            self.config.settings.lcm_diffusion_setting.strength,
+        images = self.parent.context.generate_text_to_image(
+            self.config.settings,
+            self.config.reshape_required,
+            DEVICE,
         )
         self.prepare_images(images)
         self.after_generation()

--- a/src/frontend/gui/lora_widget.py
+++ b/src/frontend/gui/lora_widget.py
@@ -143,7 +143,7 @@ class LoraModelsWidget(QWidget):
         if not path.exists(settings.lora.path):
             QMessageBox.information(self.parent, "Error", "Invalid LoRA model path!")
             return
-        pipeline = get_context(InterfaceType.GUI).lcm_text_to_image.pipeline
+        pipeline = self.parent.context.lcm_text_to_image.pipeline
         if not pipeline:
             QMessageBox.information(
                 self.parent,
@@ -153,7 +153,7 @@ class LoraModelsWidget(QWidget):
             return
         settings.lora.enabled = True
         load_lora_weight(
-            get_context(InterfaceType.GUI).lcm_text_to_image.pipeline,
+            self.parent.context.lcm_text_to_image.pipeline,
             settings,
         )
         lora_widget = _LoraWidget()
@@ -178,7 +178,7 @@ class LoraModelsWidget(QWidget):
             )
         if len(update_weights) > 0:
             update_lora_weights(
-                get_context(InterfaceType.GUI).lcm_text_to_image.pipeline,
+                self.parent.context.lcm_text_to_image.pipeline,
                 app_settings.settings.lcm_diffusion_setting,
                 update_weights,
             )


### PR DESCRIPTION
This PR fixes double RAM usage when switching pipelines in the Qt GUI. The issue was caused by using uninitialized config settings for the different GUI tabs.
I've tried all generation modes in the CLI, Qt and Web GUIs and it seems the issue is gone.