### PR TITLE
Fix PyTorch version to resolve OpenVINO _attention_scale crash on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 accelerate==1.6.0
+torch==2.4.1
+torchvision==0.19.1
+torchaudio==2.4.1
 diffusers==0.33.0
 transformers==4.48.0
 PyQt5


### PR DESCRIPTION
Hi! I noticed that when installing on Windows, the environment defaults to PyTorch 2.5+, which causes an ImportError: cannot import name '_attention_scale' crash when trying to generate images using OpenVINO.

I pinned the torch, torchvision, and torchaudio requirements to the stable 2.4.1 versions to ensure a working installation out of the box for future Windows users.